### PR TITLE
Update A1 sim version to 2.3.0

### DIFF
--- a/oran_oom/a1simulator/values.yaml
+++ b/oran_oom/a1simulator/values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: 'nexus3.o-ran-sc.org:10004/o-ran-sc'
   name: a1-simulator
-  tag: 2.2.0
+  tag: 2.3.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Fix A1 sim value 2.2.0 not pullable anymore, 2.3.0 is ok and starts